### PR TITLE
Fix missing docx dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,14 @@ End setup instructions
 -->
 
 
-3. Customize whatever you'd like in the code.
-4. Open the folder LangGraph Studio!
+3. Install the required dependencies:
+
+```bash
+pip install -r pyproject.toml
+```
+
+4. Customize whatever you'd like in the code.
+5. Open the folder LangGraph Studio!
 
 ## How to customize
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "langchain-fireworks>=0.1.7",
     "python-dotenv>=1.0.1",
     "langchain-tavily>=0.1",
+    "python-docx>=1.0",
 ]
 
 


### PR DESCRIPTION
## Summary
- add `python-docx` to dependencies
- document installing dependencies in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6850bf7160388326a00489e5e338fda1